### PR TITLE
Update to Kalo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,44 @@
-## [v0.3.0](https://github.com/lystable/guidelines/tree/v0.3.0) (Unreleased)
+## [v0.3.0](https://github.com/kalohq/guidelines/tree/v0.3.0) (Unreleased)
 
-[Compare to previous release](https://github.com/lystable/guidelines/compare/v0.2.0...v0.3.0)
-
-**Added**:
-
-
-
-
-## [v0.2.0](https://github.com/lystable/guidelines/tree/v0.2.0) (Unreleased)
-
-[Compare to previous release](https://github.com/lystable/guidelines/compare/v0.1.2...v0.2.0)
-
-**Added**:
-
-- Feature/release process refresh 
-  ([@yannispanousis](https://github.com/yannispanousis/)
-  in [\#21](https://github.com/lystable/guidelines/pull/21/))
-- Master back into Develop 
-  ([@yannispanousis](https://github.com/yannispanousis/)
-  in [\#20](https://github.com/lystable/guidelines/pull/20/))
-
-
-
-## [v0.1.2](https://github.com/lystable/guidelines/tree/v0.1.2) (Unreleased)
-
-[Compare to previous release](https://github.com/lystable/guidelines/compare/v0.1.1...v0.1.2)
-
-**Added**:
-
-- Master back into develop 
-  ([@yannispanousis](https://github.com/yannispanousis/)
-  in [\#18](https://github.com/lystable/guidelines/pull/18/))
-- Release v0.1.1 
-  ([@yannispanousis](https://github.com/yannispanousis/)
-  in [\#17](https://github.com/lystable/guidelines/pull/17/))
-
-
-
-## [v0.1.1](https://github.com/lystable/guidelines/tree/v0.1.1) (Unreleased)
-
-[Compare to previous release](https://github.com/lystable/guidelines/compare/v0.1.0...v0.1.1)
+[Compare to previous release](https://github.com/kalohq/guidelines/compare/v0.2.0...v0.3.0)
 
 **Added**:
 
 
 
 
+## [v0.2.0](https://github.com/kalohq/guidelines/tree/v0.2.0) (Unreleased)
+
+[Compare to previous release](https://github.com/kalohq/guidelines/compare/v0.1.2...v0.2.0)
+
+**Added**:
+
+- Feature/release process refresh
+  ([@yannispanousis](https://github.com/yannispanousis/)
+  in [\#21](https://github.com/kalohq/guidelines/pull/21/))
+- Master back into Develop
+  ([@yannispanousis](https://github.com/yannispanousis/)
+  in [\#20](https://github.com/kalohq/guidelines/pull/20/))
+
+
+
+## [v0.1.2](https://github.com/kalohq/guidelines/tree/v0.1.2) (Unreleased)
+
+[Compare to previous release](https://github.com/kalohq/guidelines/compare/v0.1.1...v0.1.2)
+
+**Added**:
+
+- Master back into develop
+  ([@yannispanousis](https://github.com/yannispanousis/)
+  in [\#18](https://github.com/kalohq/guidelines/pull/18/))
+- Release v0.1.1
+  ([@yannispanousis](https://github.com/yannispanousis/)
+  in [\#17](https://github.com/kalohq/guidelines/pull/17/))
+
+
+
+## [v0.1.1](https://github.com/kalohq/guidelines/tree/v0.1.1) (Unreleased)
+
+[Compare to previous release](https://github.com/kalohq/guidelines/compare/v0.1.0...v0.1.1)
+
+**Added**:

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Lystable developer guidelines
+Kalo developer guidelines
 =============================
 
 Overview
@@ -265,12 +265,12 @@ guidelines and conventions used within that codebase.
 Open source
 -----------
 
-We love open source at Lystable and believe in being good citizens within the
+We love open source at Kalo and believe in being good citizens within the
 open source community.
 
 This means that we not only contribute back to our favourite projects when we
 can but also maintain `a number of open source libraries and frameworks
-<https://github.com/lystable>`_ of our own.
+<https://github.com/kalohq>`_ of our own.
 
 New dependencies to either internal or open source projects must be authorised
 by the CTO or the primary maintainer of the project. The licensing of any new

--- a/release-process/README.md
+++ b/release-process/README.md
@@ -1,6 +1,6 @@
 ## Local Setup
 
-- [Install dennis](https://github.com/lystable/dennis)
+- [Install dennis](https://github.com/kalohq/dennis)
 
 **All `dennis` commands should be run while inside the project-to-be-released directory.**
 

--- a/styleguides/eslint-config-lystable/README.md
+++ b/styleguides/eslint-config-lystable/README.md
@@ -1,8 +1,8 @@
-Lystable Javascript ESLint config
+Kalo Javascript ESLint config
 =================================
 
 Our default export contains all of our ESLint rules, including EcmaScript 6+ and
 React. It requires `eslint`, `eslint-config-airbnb` and `eslint-plugin-react`.
 
-1. Install with `npm install --save-dev eslint eslint-config-airbnb eslint-plugin-react eslint-config-lystable` 
+1. Install with `npm install --save-dev eslint eslint-config-airbnb eslint-plugin-react eslint-config-lystable`
 2. Add `"extends": "lystable"` to your .eslintrc

--- a/styleguides/eslint-config-lystable/package.json
+++ b/styleguides/eslint-config-lystable/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-lystable",
   "version": "6.0.0",
-  "description": "Base eslint config conforming to Lystable development guidelines",
+  "description": "Base eslint config conforming to Kalo development guidelines",
   "main": "index.js",
   "scripts": {
     "test": "ava __tests__/*.js"
@@ -10,7 +10,7 @@
     "eslint",
     "javascript",
     "config",
-    "lystable"
+    "kalo"
   ],
   "author": {
     "name": "Chris Pearce",
@@ -19,7 +19,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lystable/guidelines.git"
+    "url": "git+https://github.com/kalohq/guidelines.git"
   },
   "peerDependencies": {
     "eslint-config-airbnb": ">=13.0.0",

--- a/styleguides/javascript.md
+++ b/styleguides/javascript.md
@@ -8,7 +8,7 @@ Exceptions or extensions to the specifics discussed in that guide are
 documented here or in project specific documentation.
 
 ### Eslint Config
-Use the base [Lystable eslint config](https://www.npmjs.com/package/eslint-config-lystable) for your Javascript projects! Find details [here](eslint-config-lystable).
+Use the base [Kalo eslint config](https://www.npmjs.com/package/eslint-config-lystable) for your Javascript projects! Find details [here](eslint-config-lystable).
 
 Function definition
 -------------------

--- a/styleguides/python.rst
+++ b/styleguides/python.rst
@@ -10,7 +10,7 @@ For a more detailed style guide, please read through
 `Googles style guide <https://google.github.io/styleguide/pyguide.html>`_.
 
 In addition, below are some extensions or clarifications
-that should be followed for Lystable projects.
+that should be followed for Kalo projects.
 
 Brackets
 --------


### PR DESCRIPTION
// cc @yannispanousis 

Noticed that we have a public package for eslint. Could potentially migrate this to our new npm namespace?